### PR TITLE
Run integration tests in CircleCI + upgrade NuGet packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,83 @@
+version: 2.1
+
+orbs:
+    codecov: codecov/codecov@3
+
+jobs:
+    integration-tests:
+        docker:
+            - image: mcr.microsoft.com/dotnet/sdk:7.0
+            - image: rabbitmq:3
+        parameters:
+            project:
+                type: string
+        steps:
+            - checkout
+            - run:
+                name: Run integration tests
+                command: |
+                    dotnet test << parameters.project >> \
+                        -nodereuse:false \
+                        --configuration Test \
+                        --logger "trx"
+            - run:
+                name: Test results
+                when: always
+                command: |
+                    dotnet tool restore
+                    dotnet trx2junit ./**/**/TestResults/*.trx --output ./TestResults
+            - store_test_results:
+                  path: ./TestResults
+            - store_artifacts:
+                  path: ./TestResults
+                  destination: TestResults
+
+    build:
+        docker:
+            - image: mcr.microsoft.com/dotnet/sdk:7.0
+        parameters:
+            project:
+                type: string
+        steps:
+            - checkout
+            - run:
+                name: Install node
+                command: |
+                    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && apt-get install -y nodejs
+            - run:
+                name: Build
+                command: |
+                    dotnet publish << parameters.project >> \
+                        -nodereuse:false \
+                        --configuration Release \
+                        --self-contained \
+                        -p:PublishSingleFile=true \
+                        -p:RuntimeIdentifier=win-x64 \
+                        -o publish
+            - store_artifacts:
+                path: ./publish
+                destination: publish
+            - persist_to_workspace:
+                root: ./
+                paths:
+                    - publish
+
+workflows:
+    build_and_test:
+        jobs:
+            - integration-tests:
+                matrix:
+                    parameters:
+                        project: ["tests/Serilog.Sinks.RabbitMQ.Tests.Integration"]
+                filters:
+                    branches:
+                        ignore: master
+    build_master:
+        jobs:
+            - build:
+                matrix:
+                    parameters:
+                        project: ["src/Serilog.Sinks.RabbitMQ"]
+                filters:
+                    branches:
+                        only: master

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,15 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+      "fantomas": {
+        "version": "5.1.4",
+        "commands": ["fantomas"]
+      },
+      "trx2junit": {
+        "version": "2.0.0",
+        "commands": ["trx2junit"]
+      }
+    }
+  }
+  

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,5 @@ FakesAssemblies/
 *.opt
 
 project.lock.json
+
+.idea

--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -22,9 +22,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
+++ b/src/Serilog.Sinks.RabbitMQ/Serilog.Sinks.RabbitMQ.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <TargetFrameworks>net472;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net472;net7.0</TargetFrameworks>
     <DebugType>portable</DebugType>
     <AssemblyName>Serilog.Sinks.RabbitMQ</AssemblyName>
     <PackageId>Serilog.Sinks.RabbitMQ</PackageId>

--- a/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSinkConfiguration.cs
+++ b/src/Serilog.Sinks.RabbitMQ/Sinks/RabbitMQ/RabbitMQSinkConfiguration.cs
@@ -14,7 +14,7 @@
 
 using Serilog.Events;
 using Serilog.Formatting;
-using Serilog.Formatting.Raw;
+using Serilog.Formatting.Json;
 using System;
 
 
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.RabbitMQ.Sinks.RabbitMQ
     {
         public int BatchPostingLimit { get; set; }
         public TimeSpan Period { get; set; }
-        public ITextFormatter TextFormatter { get; set; } = new RawFormatter();
+        public ITextFormatter TextFormatter { get; set; } = new JsonFormatter();
         public LogEventLevel RestrictedToMinimumLevel { get; set; } = LogEventLevel.Verbose;
     }
 }

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqClientTest.cs
@@ -16,7 +16,7 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
     public sealed class RabbitMqClientTest : IDisposable
     {
         private const string QueueName = "serilog-sink-queue";
-        private const string HostName = "rabbitmq";
+        private const string HostName = "localhost";
 
         private readonly RabbitMQClient client = new RabbitMQClient(new RabbitMQClientConfiguration
         {
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
                     await Task.Delay(50);
                 });
 
-            var receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.ToArray());
+            var receivedMessage = Encoding.UTF8.GetString(eventRaised.Arguments.Body.ToArray());
             Assert.Equal(message, receivedMessage);
         }
 
@@ -80,6 +80,11 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
                     {
                         this.connection = factory.CreateConnection();
                         this.channel = this.connection.CreateModel();
+
+                        this.channel.ExchangeDeclare("serilog-sink-exchange", "fanout");
+                        this.channel.QueueDeclare("serilog-sink-queue");
+                        this.channel.QueueBind("serilog-sink-queue", "serilog-sink-exchange", "🚀");
+
                         break;
                     }
                     catch (BrokerUnreachableException)

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqSinkTest.cs
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/RabbitMqSinkTest.cs
@@ -18,7 +18,7 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
     public sealed class RabbitMqSinkTest : IDisposable
     {
         private const string QueueName = "serilog-sink-queue";
-        private const string HostName = "rabbitmq";
+        private const string HostName = "localhost";
 
         private readonly Logger logger = new LoggerConfiguration()
             .WriteTo.RabbitMQ((clientConfiguration, sinkConfiguration) =>
@@ -91,6 +91,11 @@ namespace Serilog.Sinks.RabbitMQ.Tests.Integration
                     {
                         this.connection = factory.CreateConnection();
                         this.channel = this.connection.CreateModel();
+
+                        this.channel.ExchangeDeclare("serilog-sink-exchange", "fanout");
+                        this.channel.QueueDeclare("serilog-sink-queue");
+                        this.channel.QueueBind("serilog-sink-queue", "serilog-sink-exchange", "💯");
+
                         break;
                     }
                     catch (BrokerUnreachableException)

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
+++ b/tests/Serilog.Sinks.RabbitMQ.Tests.Integration/Serilog.Sinks.RabbitMQ.Tests.Integration.csproj
@@ -7,9 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Update="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.6.40" />
+    <PackageReference Update="SecurityCodeScan" Version="3.5.4" />
+    <PackageReference Update="SonarAnalyzer.CSharp" Version="9.5.0.73987">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Adds a CircleCI job to run integration tests and upgrades the .NET version and NuGet packages. This will allow us to validate any additional changes to our fork that may be needed as we implement a logging stream through RMQ ([context](https://locai.slack.com/archives/C04PK5QJBDZ/p1689100563175269)).

Relevant Jira tickets: https://autostore.atlassian.net/browse/HAQ-101?jql=issueKey%20in%20(HAQ-100%2CHAQ-101)